### PR TITLE
Enhance VM detail view, list view, and API responses

### DIFF
--- a/app/lib/foreman_azure_rm/azure_sdk_adapter.rb
+++ b/app/lib/foreman_azure_rm/azure_sdk_adapter.rb
@@ -92,8 +92,7 @@ module ForemanAzureRm
     end
 
     def rgs
-      rgs = resource_client.resource_groups.list
-      rgs.map(&:name)
+      resource_client.resource_groups.list
     end
 
     def vnets

--- a/app/models/foreman_azure_rm/azure_rm.rb
+++ b/app/models/foreman_azure_rm/azure_rm.rb
@@ -94,6 +94,10 @@ module ForemanAzureRm
     end
 
     def resource_groups
+      sdk.rgs.map(&:name)
+    end
+
+    def available_resource_groups
       sdk.rgs
     end
 

--- a/app/models/foreman_azure_rm/azure_rm_compute.rb
+++ b/app/models/foreman_azure_rm/azure_rm_compute.rb
@@ -154,6 +154,27 @@ module ForemanAzureRm
         _("%{vm_size} VM Size") % {:vm_size => vm_size}
     end
 
+    def attributes
+      {
+        'id'                 => id,
+        'name'               => name,
+        'vm_size'            => vm_size,
+        'platform'           => platform,
+        'resource_group'     => resource_group,
+        'location'           => azure_vm.location,
+        'state'              => state,
+        'public_ip_address'  => public_ip_address,
+        'private_ip_address' => private_ip_address,
+        'image_uuid'         => image_uuid,
+        'os_disk_name'       => azure_vm.storage_profile.os_disk.name,
+        'os_disk_size_gb'    => os_disk_size_gb,
+        'os_disk_caching'    => os_disk_caching,
+        'storage_account_type' => premium_os_disk,
+        'data_disk_count'    => data_disks.size,
+        'tags'               => azure_vm.tags,
+      }
+    end
+
     # Following properties are for AzureRm
     # These are not part of Foreman's interface
 

--- a/app/views/compute_resources_vms/index/_azurerm.html.erb
+++ b/app/views/compute_resources_vms/index/_azurerm.html.erb
@@ -4,6 +4,9 @@
     <th><%= _('Size') %></th>
     <th><%= _('Resource Group') %></th>
     <th><%= _('Region') %></th>
+    <th><%= _('Platform') %></th>
+    <th><%= _('Public IP') %></th>
+    <th><%= _('Private IP') %></th>
     <th><%= _('State') %></th>
     <th><%= _('Actions') %></th>
   </tr>
@@ -15,7 +18,10 @@
       <td><%= vm.vm_size %></td>
       <td><%= vm.resource_group %></td>
       <td><%= vm.azure_vm.location %></td>
-      <td> <span <%= vm_power_class(vm.ready?) %>> <%= vm_state(vm) %> </span> </td>
+      <td><%= vm.platform %></td>
+      <td><%= vm.public_ip_address %></td>
+      <td><%= vm.private_ip_address %></td>
+      <td><span <%= vm_power_class(vm.ready?) %>><%= vm_state(vm) %></span></td>
       <td>
         <%= action_buttons(
                 vm_power_action(vm, authorizer),

--- a/app/views/compute_resources_vms/show/_azurerm.html.erb
+++ b/app/views/compute_resources_vms/show/_azurerm.html.erb
@@ -6,25 +6,171 @@
     </thead>
     <tbody>
       <tr>
-        <td>VM Size</td>
-        <td><%=@vm.vm_size%></td>
+        <td><%= _('VM Size') %></td>
+        <td><%= @vm.vm_size %></td>
       </tr>
       <tr>
-        <td>Location</td>
-        <td><%=@vm.azure_vm.location%></td>
+        <td><%= _('Resource Group') %></td>
+        <td><%= @vm.resource_group %></td>
       </tr>
       <tr>
-        <td>Platform</td>
-        <td><%=@vm.azure_vm.storage_profile.os_disk.os_type%></td>
+        <td><%= _('Location') %></td>
+        <td><%= @vm.azure_vm.location %></td>
       </tr>
       <tr>
-        <td>Public IP address</td>
-        <td><%=@vm.public_ip_address%></td>
+        <td><%= _('Platform') %></td>
+        <td><%= @vm.azure_vm.storage_profile.os_disk.os_type %></td>
       </tr>
       <tr>
-        <td>Private IP address</td>
-        <td><%=@vm.private_ip_address%></td>
+        <td><%= _('State') %></td>
+        <td><span <%= vm_power_class(@vm.ready?) %>><%= vm_state(@vm) %></span></td>
+      </tr>
+      <tr>
+        <td><%= _('Public IP Address') %></td>
+        <td><%= @vm.public_ip_address %></td>
+      </tr>
+      <tr>
+        <td><%= _('Private IP Address') %></td>
+        <td><%= @vm.private_ip_address %></td>
+      </tr>
+      <tr>
+        <td><%= _('Image') %></td>
+        <td><%= @vm.image_uuid %></td>
       </tr>
     </tbody>
   </table>
+
+  <table class="<%= table_css_classes %>">
+    <thead>
+    <tr><th colspan="2"><%=_('OS Disk') %></th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><%= _('OS Disk Name') %></td>
+        <td><%= @vm.azure_vm.storage_profile.os_disk.name %></td>
+      </tr>
+      <tr>
+        <td><%= _('OS Disk Size (GB)') %></td>
+        <td><%= @vm.os_disk_size_gb %></td>
+      </tr>
+      <tr>
+        <td><%= _('OS Disk Caching') %></td>
+        <td><%= @vm.os_disk_caching %></td>
+      </tr>
+      <tr>
+        <td><%= _('Storage Account Type') %></td>
+        <td><%= @vm.premium_os_disk %></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <% if @vm.data_disks.present? %>
+    <table class="<%= table_css_classes %>">
+      <thead>
+      <tr>
+        <th><%= _('Data Disk Name') %></th>
+        <th><%= _('Size (GB)') %></th>
+        <th><%= _('Caching') %></th>
+        <th><%= _('LUN') %></th>
+      </tr>
+      </thead>
+      <tbody>
+        <% @vm.data_disks.each do |disk| %>
+          <tr>
+            <td><%= disk.name %></td>
+            <td><%= disk.disk_size_gb %></td>
+            <td><%= disk.caching %></td>
+            <td><%= disk.lun %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+
+  <% if @vm.interfaces.present? %>
+    <table class="<%= table_css_classes %>">
+      <thead>
+      <tr>
+        <th><%= _('Network Interface') %></th>
+        <th><%= _('Private IP') %></th>
+        <th><%= _('Public IP') %></th>
+        <th><%= _('Primary') %></th>
+      </tr>
+      </thead>
+      <tbody>
+        <% @vm.interfaces.each do |nic| %>
+          <% nic.ip_configurations.each do |config| %>
+            <tr>
+              <td><%= nic.name %></td>
+              <td><%= config.private_ipaddress %></td>
+              <td>
+                <% if config.public_ipaddress.present? %>
+                  <% ip_id = config.public_ipaddress.id %>
+                  <% ip_rg = ip_id.split('/')[4] %>
+                  <% ip_name = ip_id.split('/')[-1] %>
+                  <%= @vm.sdk.public_ip(ip_rg, ip_name).ip_address %>
+                <% end %>
+              </td>
+              <td><%= config.primary ? _('Yes') : _('No') %></td>
+            </tr>
+          <% end %>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+
+  <% if @vm.azure_vm.tags.present? %>
+    <table class="<%= table_css_classes %>">
+      <thead>
+      <tr>
+        <th><%= _('Tag') %></th>
+        <th><%= _('Value') %></th>
+      </tr>
+      </thead>
+      <tbody>
+        <% @vm.azure_vm.tags.each do |key, value| %>
+          <tr>
+            <td><%= key %></td>
+            <td><%= value %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+
+  <% if @vm.vm_extension.present? %>
+    <table class="<%= table_css_classes %>">
+      <thead>
+      <tr><th colspan="2"><%= _('VM Extensions') %></th></tr>
+      </thead>
+      <tbody>
+        <% if @vm.script_command.present? %>
+          <tr>
+            <td><%= _('Script Command') %></td>
+            <td><%= @vm.script_command %></td>
+          </tr>
+        <% end %>
+        <% if @vm.script_uris.present? %>
+          <tr>
+            <td><%= _('Script URIs') %></td>
+            <td><%= Array(@vm.script_uris).join(', ') %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+
+  <% if @vm.nvidia_gpu_extension %>
+    <table class="<%= table_css_classes %>">
+      <thead>
+      <tr><th colspan="2"><%= _('GPU Extension') %></th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><%= _('NVIDIA GPU Driver') %></td>
+          <td><%= _('Installed') %></td>
+        </tr>
+      </tbody>
+    </table>
+  <% end %>
 </div>

--- a/test/unit/azure_rm_test.rb
+++ b/test/unit/azure_rm_test.rb
@@ -32,8 +32,13 @@ class ForemanAzureRmTest < ActiveSupport::TestCase
   test "list all resource groups" do
     mock_resource_client = mock('mock_resource_client')
     @mock_sdk.stubs(:resource_client).returns(mock_resource_client)
-    @mock_sdk.stubs(:rgs).returns(['rg1', 'rg2', 'rg3'])
-    assert ['rg1', 'rg2', 'rg3'], @azure_cr.resource_groups
+    rg1 = stub(:name => 'rg1', :id => '/subscriptions/sub/resourceGroups/rg1', :location => 'eastus')
+    rg2 = stub(:name => 'rg2', :id => '/subscriptions/sub/resourceGroups/rg2', :location => 'eastus')
+    rg3 = stub(:name => 'rg3', :id => '/subscriptions/sub/resourceGroups/rg3', :location => 'westus')
+    @mock_sdk.stubs(:rgs).returns([rg1, rg2, rg3])
+    assert_equal ['rg1', 'rg2', 'rg3'], @azure_cr.resource_groups
+    assert_equal 3, @azure_cr.available_resource_groups.size
+    assert_equal 'eastus', @azure_cr.available_resource_groups.first.location
   end
 
   context 'sdk access' do


### PR DESCRIPTION
## Summary
- **VM detail view**: Add comprehensive resource information including OS disk details, data disks, network interfaces, tags, VM extensions, GPU extension status, power state, resource group, and image reference
- **VM list view**: Add platform, public IP, and private IP columns to the VM index table for at-a-glance visibility
- **API responses**: Add `attributes` method to `AzureRmCompute` for richer API serialization; fix `available_resource_groups` endpoint to return full resource group objects (name, id, location) instead of just names

All data was already available via existing model methods and SDK adapter but was not surfaced in the views or API.

## Test plan
- [ ] Verify VM list view shows new columns (Platform, Public IP, Private IP)
- [ ] Verify VM detail view shows all new sections (OS Disk, Data Disks, NICs, Tags, Extensions)
- [ ] Verify conditional sections (data disks, tags, extensions) are hidden when no data exists
- [ ] Verify `available_resource_groups` API returns objects with name, id, and location
- [ ] Verify resource group dropdown in VM creation form still works (backward compatibility)
- [ ] Run existing unit tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)